### PR TITLE
Migrate from `name.full()` to `name_full()` to future-proof editing a user into an organization

### DIFF
--- a/docassemble/FeeWaiver/data/questions/fee_waiver.yml
+++ b/docassemble/FeeWaiver/data/questions/fee_waiver.yml
@@ -1596,9 +1596,9 @@ question: |
   Do you want to add your e-signature to your ${ form_name }?
 subquestion: |
   % if filing_basis != "filing_self":          
-  This program can put "**/s/ ${signer[0].name.full(middle="full")}**" where you would sign your name. The court will accept this as your signature.
+  This program can put "**/s/ ${signer[0].name_full()}**" where you would sign your name. The court will accept this as your signature.
   % else:
-  This program can put "**/s/ ${users[0].name.full(middle='full')}**" where you would sign your name. The court will accept this as your signature.
+  This program can put "**/s/ ${users[0].name_full()}**" where you would sign your name. The court will accept this as your signature.
   % endif
 
   If you do not add your **{e-signature}**, you must sign your paper form before you file it.
@@ -1664,9 +1664,9 @@ question: |
 signature: users[0].signature
 under: |
   % if filing_basis == "filing_self":
-    ${ users[0].name.full(middle="full") }
+    ${ users[0].name_full() }
   % else:
-    ${ signer[0].name.full(middle="full") }
+    ${ signer[0].name_full() }
   % endif
 ---
 id: court choice
@@ -1800,9 +1800,9 @@ attachments:
           ${ in_re_label }
           % else:
           % if plaintiffs.number() > 1:
-          ${ plaintiffs[0].name.full(middle="full") }, et al.
+          ${ plaintiffs[0].name_full() }, et al.
           % else:
-          ${ plaintiffs[0].name.full(middle="full") }
+          ${ plaintiffs[0].name_full() }
           % endif
           % endif
       - "defendant": |
@@ -1810,15 +1810,15 @@ attachments:
           ${ "" }
           % else:
           % if defendants.number() > 1:
-          ${ defendants[0].name.full(middle="full") }, et al.
+          ${ defendants[0].name_full() }, et al.
           % else:
-          ${ defendants[0].name.full(middle="full") }      
+          ${ defendants[0].name_full() }      
           % endif
           % endif
       - "docket_number": ${ docket_number }
       - "docket_number__1": ${ docket_number }
       - "docket_number__2": ${ docket_number }
-      - "user_name_full": ${ users[0].name.full(middle="full") }
+      - "user_name_full": ${ users[0].name_full() }
 
   - name: IL fee waiver supplement
     filename: winnebago_supplement     
@@ -1833,9 +1833,9 @@ attachments:
       - "docket_number": ${ docket_number }
       - "signer_name_full": |
           % if filing_basis != "filing_self":
-          ${ signer[0].name.full(middle="full") }
+          ${ signer[0].name_full() }
           % else:
-          ${ users[0].name.full(middle="full") }
+          ${ users[0].name_full() }
           % endif
       - "signer_phone_number": |
           % if filing_basis != "filing_self":
@@ -1845,9 +1845,9 @@ attachments:
           % endif
       - "signer_signature_slash_s": |
           % if filing_basis != "filing_self":          
-          ${ "/s/ " + signer[0].name.full(middle="full") if e_signature else '' }
+          ${ "/s/ " + signer[0].name_full() if e_signature else '' }
           % else:
-          ${ "/s/ " + users[0].name.full(middle="full") if e_signature else ''  }
+          ${ "/s/ " + users[0].name_full() if e_signature else ''  }
           % endif
 
   - name: Kankakee supplement
@@ -1862,9 +1862,9 @@ attachments:
           ${ "In re: " + in_re_label }
           % else:
           % if plaintiffs.number() > 1:
-          ${ plaintiffs[0].name.full(middle="full") }, et al.
+          ${ plaintiffs[0].name_full() }, et al.
           % else:
-          ${ plaintiffs[0].name.full(middle="full") }
+          ${ plaintiffs[0].name_full() }
           % endif
           % endif
       - "defendant": |
@@ -1872,17 +1872,17 @@ attachments:
           ${ "" }
           % else:
           % if defendants.number() > 1:
-          ${ defendants[0].name.full(middle="full") }, et al.
+          ${ defendants[0].name_full() }, et al.
           % else:
-          ${ defendants[0].name.full(middle="full") }      
+          ${ defendants[0].name_full() }      
           % endif
           % endif
       - "docket_number": ${ docket_number }
       - "signer_signature_slash_s": |
           % if filing_basis != "filing_self":          
-          ${ "/s/ " + signer[0].name.full(middle="full") if e_signature else '' }
+          ${ "/s/ " + signer[0].name_full() if e_signature else '' }
           % else:
-          ${ "/s/ " + users[0].name.full(middle="full") if e_signature else ''  }
+          ${ "/s/ " + users[0].name_full() if e_signature else ''  }
           % endif
       - "date": ${ today() if e_signature else '' }
 
@@ -1899,9 +1899,9 @@ attachments:
           ${ in_re_label }
           % else:
           % if plaintiffs.number() > 1:
-          ${ plaintiffs[0].name.full(middle="full") }, et al.
+          ${ plaintiffs[0].name_full() }, et al.
           % else:
-          ${ plaintiffs[0].name.full(middle="full") }
+          ${ plaintiffs[0].name_full() }
           % endif
           % endif
       - "defendant": |
@@ -1909,9 +1909,9 @@ attachments:
           ${ "" }
           % else:
           % if defendants.number() > 1:
-          ${ defendants[0].name.full(middle="full") }, et al.
+          ${ defendants[0].name_full() }, et al.
           % else:
-          ${ defendants[0].name.full(middle="full") }      
+          ${ defendants[0].name_full() }      
           % endif
           % endif
       - "docket_number": ${ docket_number }
@@ -1920,20 +1920,20 @@ attachments:
       - "docket_number__3": ${ docket_number }
       - "filing_self_cb": ${ True if filing_basis == "filing_self" else ""}
       - "filing_obo_cb": ${ True if filing_basis != "filing_self" else ""}
-      - "user_name_full": ${ users[0].name.full(middle="full") }
+      - "user_name_full": ${ users[0].name_full() }
       - "user_address_one_line": ${ users[0].address.on_one_line(bare=True) }
       - "signer_name_full": |
           % if filing_basis != "filing_self":
-          ${ signer[0].name.full(middle="full") }
+          ${ signer[0].name_full() }
           % else:
-          ${ users[0].name.full(middle="full") }
+          ${ users[0].name_full() }
           % endif
       - "user_address_one_line__2": ${ users[0].address.on_one_line(bare=True) }
       - "signer_signature_no_slash": |
           % if filing_basis != "filing_self":          
-          ${ signer[0].name.full(middle="full") if e_signature else '' }
+          ${ signer[0].name_full() if e_signature else '' }
           % else:
-          ${ users[0].name.full(middle="full") if e_signature else ''  }
+          ${ users[0].name_full() if e_signature else ''  }
           % endif
       - "signer_email": |
           % if filing_basis != "filing_self":
@@ -2583,14 +2583,14 @@ review:
       **Plaintiffs / Petitioners:**
 
       % for item in plaintiffs:
-        * ${ item.name.full(middle="full") }
+        * ${ item.name_full() }
       % endfor
   - Edit: defendants.revisit
     button: |
       **Defendants / Respondents:**
 
       % for item in defendants:
-        * ${ item.name.full(middle="full") }
+        * ${ item.name_full() }
       % endfor
   - Edit: in_re_check
     button: |
@@ -2618,12 +2618,12 @@ review:
   - Edit: users[0].name.first
     button: |
       **Your name:**
-      ${ users[0].name.full(middle="full") }
+      ${ users[0].name_full() }
     show if: filing_basis == "filing_self"
   - Edit: users[0].name.first
     button: |
       **Name of person you are filing for:**
-      ${ users[0].name.full(middle="full") }
+      ${ users[0].name_full() }
     show if: filing_basis != "filing_self"
   - Edit: users[0].address.address
     button: |
@@ -2636,7 +2636,7 @@ review:
   - Edit: signer[0].name.first
     button: |
       **Your name:**
-      ${ signer[0].name.full(middle="full") }
+      ${ signer[0].name_full() }
     show if: filing_basis != "filing_self"
   - Edit: substantial_hardship_explanation
     button: |
@@ -2715,7 +2715,7 @@ table: plaintiffs.table
 rows: plaintiffs
 columns:
   - name: |
-      row_item.name.full(middle="full") if defined("row_item.name.first") else ""
+      row_item.name_full() if defined("row_item.name.first") else ""
 edit:
   - name.first
 confirm: True
@@ -2734,7 +2734,7 @@ table: defendants.table
 rows: defendants
 columns:
   - name: |
-      row_item.name.full(middle="full") if defined("row_item.name.first") else ""
+      row_item.name_full() if defined("row_item.name.first") else ""
 edit:
   - name.first
 confirm: True
@@ -2754,7 +2754,7 @@ table: users.table
 rows: users
 columns:
   - Name: |
-      row_item.name.full(middle="full") if defined("row_item.name.first") else ""
+      row_item.name_full() if defined("row_item.name.first") else ""
 edit:
   - name.first
 confirm: True
@@ -2763,7 +2763,7 @@ table: other_parties.table
 rows: other_parties
 columns:
   - Name: |
-      row_item.name.full(middle="full") if defined("row_item.name.first") else ""
+      row_item.name_full() if defined("row_item.name.first") else ""
 edit:
   - name.first
 confirm: True
@@ -3256,14 +3256,14 @@ review:
       **Plaintiffs / Petitioners:**
 
       % for item in plaintiffs:
-        * ${ item.name.full(middle="full") }
+        * ${ item.name_full() }
       % endfor
   - Edit: defendants.revisit
     button: |
       **Defendants / Respondents:**
 
       % for item in defendants:
-        * ${ item.name.full(middle="full") }
+        * ${ item.name_full() }
       % endfor
   - Edit: in_re_check
     button: |
@@ -3301,12 +3301,12 @@ review:
   - Edit: users[0].name.first
     button: |
       **Your name:**
-      ${ users[0].name.full(middle="full") }
+      ${ users[0].name_full() }
     show if: filing_basis == "filing_self"
   - Edit: users[0].name.first
     button: |
       **Name of person you are filing for:**
-      ${ users[0].name.full(middle="full") }
+      ${ users[0].name_full() }
     show if: filing_basis != "filing_self"
   - Edit: substantial_hardship_explanation
     button: |
@@ -3335,7 +3335,7 @@ review:
   - Edit: signer[0].name.first
     button: |
       **Your name:**
-      ${ signer[0].name.full(middle="full") }
+      ${ signer[0].name_full() }
     show if: filing_basis != "filing_self"
   - Edit: signer[0].address.address
     button: |


### PR DESCRIPTION

Previously, it was possible to have leftover text in the .name.last field which would not be removed
if the user used a review screen and changed the person type from Individual to Business.

This PR replaces any use of `.name.full(middle="full")` with `name_full()`, which in a future
version of the AssemblyLine framework will solve this problem by not printing the last name
when the `person_type` is "business"

## How this change was made

This change was made by searching for any repos that had the text `name.full(middle="full") using gh-search,
and then the text was replaced with turbolift --sed as follows:

```bash
turbolift foreach -- bash -lc '
  # 1) enable ** to recurse
  shopt -s globstar

  # 2) for each .yml, replace both " and '\'' variants
  for f in **/*.yml; do
    sed -i "s/name\.full(middle=\"full\")/name_full()/g" "$f"
    sed -i "s/name\.full(middle='\''full'\'')/name_full()/g" "$f"
  done
'
```

<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>